### PR TITLE
go1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,6 @@ jobs:
       - run: |
           test '${{ steps.go-version.outputs.minimal }}' == '1.13'
       - run: |
-          test '${{ steps.go-version.outputs.latest }}' == '1.17'
+          test '${{ steps.go-version.outputs.latest }}' == '1.18'
       - run: |
-          test '${{ steps.go-version.outputs.matrix }}' == '["1.17","1.16","1.15","1.14","1.13"]'
+          test '${{ steps.go-version.outputs.matrix }}' == '["1.18","1.17","1.16","1.15","1.14","1.13"]'

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ recommended to set a token:
 
 ```yaml
   env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GITHUB_TOKEN: ${{ github.token }}
 ```
 
 ## Outputs
@@ -85,7 +85,7 @@ jobs:
       - uses: arnested/go-version-action@v1
         id: go-version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Install Go ${{ steps.go-version.outputs.minimal }}
         uses: actions/setup-go@v2
         with:
@@ -116,7 +116,7 @@ jobs:
     - uses: arnested/go-version-action@v1
       id: versions
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "go-version-action",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",


### PR DESCRIPTION
- Add go1.18 to test case
- Improve README
- Regenerate package-lock.json
