### PR TITLE
Remove reviewers from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,8 @@ updates:
     schedule:
       interval: monthly
       timezone: Europe/Copenhagen
-    reviewers:
-      - arnested
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
       timezone: Europe/Copenhagen
-    reviewers:
-      - arnested


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
