### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 ---
 name: Build and test
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/arnested/go-version-action/security/code-scanning/8](https://github.com/arnested/go-version-action/security/code-scanning/8)

To fix the issue, set an explicit `permissions` block granting only the minimal required permissions to the GITHUB_TOKEN for this workflow. Since none of the shown workflow steps require write or elevated permissions (there are no steps for checking in code, opening issues, or modifying PRs), it is appropriate to add `permissions: { contents: read }` at the top-level of the workflow. This restricts the GITHUB_TOKEN to only have read access to repository contents for all jobs in this workflow, satisfying CodeQL and security best-practices. The permission block should be inserted after the `name: Build and test` line (i.e., as line 3). No other workflow, code, or method changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
