### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 ---
 name: Lint
+permissions:
+  contents: read
 on: pull_request
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/arnested/go-version-action/security/code-scanning/5](https://github.com/arnested/go-version-action/security/code-scanning/5)

The best way to address the problem is to explicitly restrict the GITHUB_TOKEN permissions at the workflow level by adding a `permissions:` block to the root of the workflow. This ensures that all jobs default to these permissions unless overridden locally.  
For pure linting jobs such as these, the only required permission is `contents: read`. No job is expected to modify repository contents, publish artifacts, comment on issues or PRs, etc.  
Therefore, add the following block after the `name: Lint` and before `on: pull_request` (or immediately after `on:` if conventionally preferred):  
```yaml
permissions:
  contents: read
```  
Only the file `.github/workflows/lint.yml` needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
