### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 ---
 name: Lint
 on: pull_request
+permissions:
+  contents: read
 
 jobs:
   yamllint:


### PR DESCRIPTION
Potential fix for [https://github.com/arnested/go-version-action/security/code-scanning/4](https://github.com/arnested/go-version-action/security/code-scanning/4)

To resolve the issue, you should explicitly add a `permissions` block to the workflow YAML file defining the minimum required permissions. For linting workflows such as this, only `contents: read` is needed, since the jobs only read files for linting and do not modify repository contents, interact with issues, or comment on pull requests. The `permissions` block should be added at the workflow root (top-level, just under `name` or `on`), so it applies to all jobs unless a job-specific override is needed.  
Edit `.github/workflows/lint.yml`:  
- Add the following block directly after the `name: Lint` (line 2) or after the `on: pull_request` (line 3):  
  ```yaml
  permissions:
    contents: read
  ```  
No new methods, imports, or package dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
