### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/arnested/go-version-action/security/code-scanning/1](https://github.com/arnested/go-version-action/security/code-scanning/1)

To fix this issue, you should add a `permissions` block to the workflow to scope token access. This can be done either at the workflow root (affecting all jobs) or at the job level (affecting just one job). As all jobs are within one block (`release`), adding at the job level is fine and more flexible. Given the operations—pushing commits/tags and creating releases—the job needs `contents: write` for code pushes, and also `packages: write` if any package-related permissions are needed. For creating releases, `contents: write` is usually sufficient. Unless other scopes are strictly needed, you should explicitly set only the required scopes. The minimal and safe recommendation is:

```yaml
permissions:
  contents: write
```

Add this block to the `release` job (line 12), just before or after `runs-on: ubuntu-latest`. This change will restrict the token issued to this job to only have write access to repository contents (commits, tags, and releases). No other permissions (such as admin or broader write) will be granted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
