### PR TITLE
Adds option to only show latest patch versions

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -28,13 +28,13 @@ test('test latest version', () => {
 
 test('test version matrix', () => {
   const t = JSON.parse(fs.readFileSync('__tests__/testdata/dl.json', 'utf8'))
-  const m = matrix('1.16', false, false, t)
+  const m = matrix('1.16', false, false, false, t)
   expect(m).toEqual(['1.16', '1.17', '1.18'])
 })
 
 test('test unstable version matrix', () => {
   const t = JSON.parse(fs.readFileSync('__tests__/testdata/dl.json', 'utf8'))
-  const m = matrix('1.16', true, false, t)
+  const m = matrix('1.16', true, false, false, t)
   expect(m).toEqual([
     '1.16beta1',
     '1.16rc1',
@@ -52,7 +52,7 @@ test('test unstable version matrix', () => {
 
 test('test patch level version matrix', () => {
   const t = JSON.parse(fs.readFileSync('__tests__/testdata/dl.json', 'utf8'))
-  const m = matrix('1.16', false, true, t)
+  const m = matrix('1.16', false, true, false, t)
   expect(m).toEqual([
     '1.16',
     '1.16.1',
@@ -85,7 +85,7 @@ test('test patch level version matrix', () => {
 
 test('test patch level, unstable version matrix', () => {
   const t = JSON.parse(fs.readFileSync('__tests__/testdata/dl.json', 'utf8'))
-  const m = matrix('1.16', true, true, t)
+  const m = matrix('1.16', true, true, false, t)
   expect(m).toEqual([
     '1.16beta1',
     '1.16rc1',
@@ -122,4 +122,17 @@ test('test patch level, unstable version matrix', () => {
     '1.18rc1',
     '1.18'
   ])
+})
+
+test('test patch level with latest patches only', () => {
+  const t = JSON.parse(fs.readFileSync('__tests__/testdata/dl.json', 'utf8'))
+  const m = matrix('1.16', false, true, true, t)
+  expect(m).toEqual(['1.16.15', '1.17.8', '1.18'])
+})
+
+test('test patch level with latest patches only and unstable throws error', () => {
+  const t = JSON.parse(fs.readFileSync('__tests__/testdata/dl.json', 'utf8'))
+  expect(() => {
+    matrix('1.16', true, true, true, t)
+  }).toThrow('The options "unstable" and "latest-patches-only" cannot be used together')
 })

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: Include the patch levels on the versions (default is major.minor)
     required: false
     default: 'false'
+  latest-patches-only:
+    description: When patch-level is true, only include the latest patch version of each major.minor version in the matrix. Does nothing if patch-level is false. Cannot be used with unstable.
+    required: false
+    default: 'false'
 outputs:
   go-mod-version:
     description: The Go version specified by go.mod

--- a/src/main.js
+++ b/src/main.js
@@ -21,11 +21,18 @@ async function run() {
     const withUnsupported = core.getBooleanInput('unsupported')
     const withUnstable = core.getBooleanInput('unstable')
     const withPatchLevel = core.getBooleanInput('patch-level')
+    const withLatestPatches = core.getBooleanInput('latest-patches-only')
     const content = gomod(`${workingDirectory}/go.mod`)
     const name = modulename(content)
     const goModVersion = getGoModVersion(content)
     const versions = await getVersions(withUnsupported)
-    const mat = matrix(goModVersion, withUnstable, withPatchLevel, versions)
+    const mat = matrix(
+      goModVersion,
+      withUnstable,
+      withPatchLevel,
+      withLatestPatches,
+      versions
+    )
     const lat = latest(mat)
     const min = minimal(mat)
 


### PR DESCRIPTION
Fixes #535 with tests and documentation. I know you probably haven't had a chance to review the issue yet, but opening this PR as a way to get the conversation started. Feel free to reject if you don't like this idea.

Some assumptions:
- `latest-patches-only` is the flag that was used, but open to alternatives
- only works when `patch-level` is set to `true`
- should not work with `unstable` as those are not patch versions

Happy to discuss any aspect of this implementation if you have questions, comments, or concerns.